### PR TITLE
readme: Fix the cargo run --bin flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ cargo build
 ## Run
 
 ```bash
-cargo run --package {{project-name}} -bin {{project-name}}
+cargo run --package {{project-name}} --bin {{project-name}}
 ```


### PR DESCRIPTION
The flag for `cargo run` is `--bin`, not `-bin`.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>