### PR TITLE
ebpf: set target and enable -Z build-std in .cargo/config.toml

### DIFF
--- a/{{project-name}}-ebpf/.cargo/config.toml
+++ b/{{project-name}}-ebpf/.cargo/config.toml
@@ -1,2 +1,6 @@
 [build]
 target-dir = "../target"
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core"]


### PR DESCRIPTION
This makes it possible to build with:

    cd {{project-name}}-ebpf && cargo +nightly build