### PR TITLE
ebpf: set opt-level = 2

### DIFF
--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [profile.dev]
 panic = "abort"
+opt-level = 2
 overflow-checks = false
 
 [profile.release]


### PR DESCRIPTION
Pretty much all non trivial programs need at least opt-level=2 to compile and link successfully