### PR TITLE
remove unused import std::convert::TryFrom

### DIFF
--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -14,6 +14,7 @@ use aya::programs::SockOps;
 use aya::maps::{MapRefMut,SockHash};
 use aya::programs::SkMsg;
 use {{crate_name}}_common::SockKey;
+use std::convert::TryFrom;
 {%- when "xdp" -%}
 use aya::programs::{Xdp, XdpFlags};
 {%- when "classifier" -%}
@@ -28,7 +29,7 @@ use aya::{programs::Lsm, Btf};
 use aya::{programs::BtfTracePoint, Btf};
 {%- endcase %}
 use std::{
-    convert::{TryFrom,TryInto},
+    convert::TryInto,
     sync::Arc,
     sync::atomic::{AtomicBool, Ordering},
     thread,


### PR DESCRIPTION
remove unused `std::convert::TryFrom` import to avoid the warning in the generated projects:
```
warning: unused import: `TryFrom`
 --> myapp/src/main.rs:4:15
  |
4 |     convert::{TryFrom,TryInto},
  |               ^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `myapp` (bin "myapp") generated 1 warning
```