### PR TITLE
ebpf: Add rust-analyzer settings for coc.nvim

### DIFF
--- a/{{project-name}}-ebpf/.vim/coc-settings.json
+++ b/{{project-name}}-ebpf/.vim/coc-settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.target": "bpfel-unknown-none",
+    "rust-analyzer.checkOnSave.allTargets": false
+}


### PR DESCRIPTION
Mirrors the settings for vscode introduced in e81a33e

Signed-off-by: William Findlay <william@williamfindlay.com>