### PR TITLE
userspace: use include_bytes_aligned! instead of --path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ cargo build
 ## Run
 
 ```bash
-cargo xtask run -p
+cargo xtask run
 ```

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ esac
 
 cargo generate -v --path "${TEMPLATE_DIR}" -n test -d program_type="${PROG_TYPE}" ${ADDITIONAL_ARGS}
 pushd test
-cargo build
 cargo xtask build-ebpf
+cargo build
 popd
 exit 0

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -16,9 +16,6 @@ pub struct Options {
     /// The command used to wrap your application
     #[structopt(short, long, default_value = "sudo -E")]
     pub runner: String,
-    /// A convenience flag that will supply `--path /path/to/bpf/object` to your application
-    #[structopt(short = "p", long)]
-    pub supply_path: bool,
     /// Arguments to pass to your application
     #[structopt(name = "args", last = true)]
     pub run_args: Vec<String>,
@@ -51,14 +48,9 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
     let bin_path = format!("target/{}/{{project-name}}", profile);
-    let bpf_path = format!("target/{}/{}/{{project-name}}", opts.bpf_target, profile);
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();
-    if opts.supply_path {
-        run_args.push("--path");
-        run_args.push(bpf_path.as_str());
-    };
 
     // configure args
     let mut args: Vec<_> = opts.runner.trim().split_terminator(" ").collect();


### PR DESCRIPTION
Per the discussion on Discord, this patch changes the template to use `include_bytes_aligned!` rather than a `--path` flag and `Bpf::load_file`. Note that this obviates the need for `structopt` in most cases, and produces a dead code warning for our `Opt` struct. I left this in for two reasons:

1. I think it's realistic to assume that the end-user will want `structopt` as their application grows in complexity.
2. `structopt` is still needed for many program types (e.g. XDP), and adding too many if-statements in too many places will just needlessly complicate the template.