### PR TITLE
for xdp, retry load with SKB_MODE flags

### DIFF
--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -16,6 +16,7 @@ use aya::programs::SkMsg;
 use {{crate_name}}_common::SockKey;
 use std::convert::TryFrom;
 {%- when "xdp" -%}
+use anyhow::Context;
 use aya::programs::{Xdp, XdpFlags};
 {%- when "classifier" -%}
 use aya::programs::{tc, SchedClassifier, TcAttachType};
@@ -104,7 +105,8 @@ fn try_main() -> Result<(), anyhow::Error> {
     {%- when "xdp" -%}
     let program: &mut Xdp = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     program.load()?;
-    program.attach(&opt.iface, XdpFlags::default())?;
+    program.attach(&opt.iface, XdpFlags::default())
+        .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
     {%- when "classifier" -%}
     tc::qdisc_add_clsact(&opt.iface)?;
     let program: &mut SchedClassifier = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;


### PR DESCRIPTION
I believe the current user experience for some new users with the XDP example may be less than ideal: then run examples in the book, get a failure if no native XDP support, and then have to manually modify the code to use XdpFlags::SKB_MODE. Suggesting to automatically try it on program loading failure, notifying the user.