### PR TITLE
Use release profile for eBPF programs by default

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -35,25 +35,24 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[structopt(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Build the release target
-    #[structopt(long)]
-    pub release: bool,
+    /// Build profile for eBPF programs
+    #[structopt(default_value = "release", long)]
+    pub profile: String,
 }
 
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
-    let mut args = vec![
+    let args = vec![
         "+nightly",
         "build",
         "--verbose",
         target.as_str(),
         "-Z",
         "build-std=core",
+        "--profile",
+        opts.profile.as_str(),
     ];
-    if opts.release {
-        args.push("--release")
-    }
     let status = Command::new("cargo")
         .current_dir(&dir)
         .args(&args)

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -10,9 +10,9 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[structopt(default_value = "bpfel-unknown-none", long)]
     pub bpf_target: Architecture,
-    /// Build and run the release target
-    #[structopt(long)]
-    pub release: bool,
+    /// Build profile for userspace program
+    #[structopt(default_value = "dev", long)]
+    pub profile: String,
     /// The command used to wrap your application
     #[structopt(short, long, default_value = "sudo -E")]
     pub runner: String,
@@ -23,10 +23,7 @@ pub struct Options {
 
 /// Build the project
 fn build(opts: &Options) -> Result<(), anyhow::Error> {
-    let mut args = vec!["build"];
-    if opts.release {
-        args.push("--release")
-    }
+    let args = vec!["build", "--profile", opts.profile.as_str()];
     let status = Command::new("cargo")
         .args(&args)
         .status()
@@ -40,14 +37,17 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // build our ebpf program followed by our application
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
-        release: opts.release,
+        profile: opts.profile.clone(),
     })
     .context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace application")?;
 
-    // profile we are building (release or debug)
-    let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{}/{{project-name}}", profile);
+    let target_dir = match opts.profile.as_str() {
+        "dev" | "test" => "debug",
+        "bench" | "release" => "release",
+        _ => opts.profile.as_str(),
+    };
+    let bin_path = format!("target/{}/{{project-name}}", target_dir);
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -11,12 +11,6 @@ aya-bpf = { git = "http://github.com/aya-rs/aya", branch = "main" }
 name = "{{ project-name }}"
 path = "src/main.rs"
 
-[profile.dev]
-panic = "abort"
-debug = 1
-opt-level = 2
-overflow-checks = false
-
 [profile.release]
 panic = "abort"
 

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -67,11 +67,6 @@ async fn main() -> Result<(), anyhow::Error> {
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
-    #[cfg(debug_assertions)]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/{{project-name}}"
-    ))?;
-    #[cfg(not(debug_assertions))]
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;


### PR DESCRIPTION
This change removes the differentiation between release and dev profiles
for eBPF programs. There is no way eBPF programs can be debugged and
building them with dev profile just makes them slower and often unable
to be verified. They should be always built with the release profile.

After this change, `cargo xtask build-ebpf` is going to build eBPF
programs with release profile. And the userspace program is going to
include eBPF program bytes from target/release/. Regardless of which
profile is being used in the userspace program.

`cargo xtask build-ebpf` has the --profile argument which can be
optionally used (i.e. for user-defined profiles), but by default the
value of that option is `release`.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>