### PR TITLE
Add `attach` attribute for cgroup SKB

### DIFF
--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -183,7 +183,11 @@ use aya_bpf::{
     programs::SkBuffContext,
 };
 
-#[cgroup_skb(name="{{crate_name}}")]
+{% if direction == "Ingress" -%}
+#[cgroup_skb(name="{{crate_name}}",attach="ingress")]
+{%- else -%}
+#[cgroup_skb(name="{{crate_name}}",attach="egress")]
+{%- endif %}
 pub fn {{crate_name}}(ctx: SkBuffContext) -> i32 {
     match unsafe { try_{{crate_name}}(ctx) } {
         Ok(ret) => ret,


### PR DESCRIPTION
When cgroup SKB is generated via template, the `attach` attribute is
always missing and the program does not work by default.

Please refer to https://github.com/aya-rs/aya/issues/225.

This patch fixes it.