### PR TITLE
Add template for socket_filter program type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - uprobe
           - uretprobe
           - sock_ops
+          - sock_filter
           - sk_msg
           - xdp
           - classifier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - uprobe
           - uretprobe
           - sock_ops
-          - sock_filter
+          - socket_filter
           - sk_msg
           - xdp
           - classifier

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -13,6 +13,7 @@ choices = [
     "uprobe",
     "uretprobe",
     "sock_ops",
+    "sock_filter",
     "sk_msg",
     "xdp",
     "classifier",

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -13,7 +13,7 @@ choices = [
     "uprobe",
     "uretprobe",
     "sock_ops",
-    "sock_filter",
+    "socket_filter",
     "sk_msg",
     "xdp",
     "classifier",

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -245,6 +245,16 @@ pub fn {{tracepoint_name}}(ctx: BtfTracePointContext) -> i32 {
 unsafe fn try_{{tracepoint_name}}(_ctx: BtfTracePointContext) -> Result<i32, i32> {
     Ok(0)
 }
+{%- when "socket_filter" %}
+use aya_bpf::{
+    macros::socket_filter,
+    programs::SkBuffContext,
+};
+
+#[socket_filter(name="{{crate_name}}")]
+pub fn {{crate_name}}(_ctx: SkBuffContext) -> i64 {
+    return 0
+}
 {%- endcase %}
 
 #[panic_handler]


### PR DESCRIPTION
This patch adds template for socket_filter.
e.g.

```sh
cargo generate --path ~/dev/aya-template \
         --name my-test \
	 -d program_type=socket_filter
```

(The template works with this bug fix for aya https://github.com/aya-rs/aya/pull/228.)