### PR TITLE
use edition 2021

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/{{project-name}}-common/Cargo.toml
+++ b/{{project-name}}-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "{{project-name}}-common"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "{{ project-name }}-ebpf"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "http://github.com/aya-rs/aya", branch = "main" }

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -14,7 +14,6 @@ use aya::programs::SockOps;
 use aya::maps::{MapRefMut,SockHash};
 use aya::programs::SkMsg;
 use {{crate_name}}_common::SockKey;
-use std::convert::TryFrom;
 {%- when "xdp" -%}
 use anyhow::Context;
 use aya::programs::{Xdp, XdpFlags};
@@ -31,7 +30,6 @@ use aya::{programs::BtfTracePoint, Btf};
 {%- endcase %}
 use log::info;
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
-use std::convert::TryInto;
 use structopt::StructOpt;
 use tokio::signal;
 


### PR DESCRIPTION
PR converts to use Rust edition 2021 and remove the imports `use std::convert::{TryInto, TryFrom}` which are now in the standard prelude - https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html.