### PR TITLE
readme: Remove the --release parameter from build-ebpf xtask

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 cargo xtask build-ebpf
 ```
 
-To perform a release build you can use the `--release` flag.
-You may also change the target architecture with the `--target` flag
+You may change the target architecture with the `--target` flag.
 
 ## Build Userspace
 


### PR DESCRIPTION
That flag went away with the following PR:

https://github.com/aya-rs/aya-template/pull/31

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>