### PR TITLE
ebpf: Make the dev target identical to release

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -35,24 +35,25 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[structopt(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Build profile for eBPF programs
-    #[structopt(default_value = "release", long)]
-    pub profile: String,
+    /// Build the release target
+    #[structopt(long)]
+    pub release: bool,
 }
 
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
-    let args = vec![
+    let mut args = vec![
         "+nightly",
         "build",
         "--verbose",
         target.as_str(),
         "-Z",
         "build-std=core",
-        "--profile",
-        opts.profile.as_str(),
     ];
+    if opts.release {
+        args.push("--release")
+    }
     let status = Command::new("cargo")
         .current_dir(&dir)
         .args(&args)

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -11,6 +11,12 @@ aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 name = "{{ project-name }}"
 path = "src/main.rs"
 
+[profile.dev]
+panic = "abort"
+debug = 1
+opt-level = 2
+overflow-checks = false
+
 [profile.release]
 panic = "abort"
 

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -12,13 +12,20 @@ name = "{{ project-name }}"
 path = "src/main.rs"
 
 [profile.dev]
-panic = "abort"
-debug = 1
-opt-level = 2
+opt-level = 3
+debug = false
+debug-assertions = false
 overflow-checks = false
+lto = true
+panic = "abort"
+incremental = false
+codegen-units = 1
+rpath = false
 
 [profile.release]
+lto = true
 panic = "abort"
+codegen-units = 1
 
 [workspace]
 members = []

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -65,6 +65,11 @@ async fn main() -> Result<(), anyhow::Error> {
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
+    #[cfg(debug_assertions)]
+    let mut bpf = Bpf::load(include_bytes_aligned!(
+        "../../target/bpfel-unknown-none/debug/{{project-name}}"
+    ))?;
+    #[cfg(not(debug_assertions))]
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;


### PR DESCRIPTION
eBPF programs cannot be debugged and those ones built with the default
dev profile are often annoying the verifier. Therefore it doesn't make
sense to compile not optimized eBPF objects.

However, we still want to let people to use the dev profile, especially
in the future when we want to get rid of xtask by using cargo binary
dependencies[0]. The trick is to have no real difference between dev and
release profile in eBPF.

This change doesn't affect the userspace part which still is going to
contain debug symbols when built with dev profile.

[0] https://rust-lang.github.io/rfcs/3028-cargo-binary-dependencies.html

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>