### PR TITLE
Use clap instead of structopt

### DIFF
--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -8,10 +8,12 @@ publish = false
 aya = { git = "https://github.com/aya-rs/aya", branch="main" }
 {{project-name}}-common = { path = "../{{project-name}}-common", features=["user"] }
 anyhow = "1.0.42"
-{% if program_type == "uprobe" %}libc = "0.2.102"{% endif %}
+clap = { version = "3.1", features = ["derive"] }
+{%- if program_type == "uprobe" %}
+libc = "0.2.102"
+{%- endif %}
 log = "0.4"
 simplelog = "0.12"
-structopt = { version = "0.3" }
 tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 
 [[bin]]

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -28,28 +28,28 @@ use aya::{programs::Lsm, Btf};
 {%- when "tp_btf" -%}
 use aya::{programs::BtfTracePoint, Btf};
 {%- endcase %}
+use clap::Parser;
 use log::info;
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
-use structopt::StructOpt;
 use tokio::signal;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Opt {
     {% if program_type == "xdp" or program_type == "classifier" -%}
-    #[structopt(short, long, default_value = "eth0")]
+    #[clap(short, long, default_value = "eth0")]
     iface: String,
     {%- elsif program_type == "sock_ops" or program_type == "cgroup_skb" -%}
-    #[structopt(short, long, default_value = "/sys/fs/cgroup/unified")]
+    #[clap(short, long, default_value = "/sys/fs/cgroup/unified")]
     cgroup_path: String,
     {%- elsif program_type == "uprobe" or program_type == "uretprobe" -%}
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pid: Option<i32>
     {%- endif %}
 }
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     TermLogger::init(
         LevelFilter::Debug,


### PR DESCRIPTION
structopt was merged into clap (starting from clap 3.0), therefore
becoming a deprecated project.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>