### PR TITLE
xtask: Use clap instead of structopt

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,8 +3,6 @@ name = "xtask"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-structopt = {version = "0.3", default-features = false }
 anyhow = "1"
+clap = { version = "3.1", features = ["derive"] }

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use structopt::StructOpt;
+use clap::Parser;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Architecture {
@@ -30,13 +30,13 @@ impl std::fmt::Display for Architecture {
     }
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Options {
     /// Set the endianness of the BPF target
-    #[structopt(default_value = "bpfel-unknown-none", long)]
+    #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
     /// Build the release target
-    #[structopt(long)]
+    #[clap(long)]
     pub release: bool,
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,21 +3,22 @@ mod run;
 
 use std::process::exit;
 
-use structopt::StructOpt;
-#[derive(StructOpt)]
+use clap::Parser;
+
+#[derive(Debug, Parser)]
 pub struct Options {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     BuildEbpf(build_ebpf::Options),
     Run(run::Options),
 }
 
 fn main() {
-    let opts = Options::from_args();
+    let opts = Options::parse();
 
     use Command::*;
     let ret = match opts.command {

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -1,23 +1,23 @@
 use std::{os::unix::process::CommandExt, process::Command};
 
 use anyhow::Context as _;
-use structopt::StructOpt;
+use clap::Parser;
 
 use crate::build_ebpf::{build_ebpf, Architecture, Options as BuildOptions};
 
-#[derive(StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Options {
     /// Set the endianness of the BPF target
-    #[structopt(default_value = "bpfel-unknown-none", long)]
+    #[clap(default_value = "bpfel-unknown-none", long)]
     pub bpf_target: Architecture,
     /// Build and run the release target
-    #[structopt(long)]
+    #[clap(long)]
     pub release: bool,
     /// The command used to wrap your application
-    #[structopt(short, long, default_value = "sudo -E")]
+    #[clap(short, long, default_value = "sudo -E")]
     pub runner: String,
     /// Arguments to pass to your application
-    #[structopt(name = "args", last = true)]
+    #[clap(name = "args", last = true)]
     pub run_args: Vec<String>,
 }
 


### PR DESCRIPTION
structopt was merged into clap (starting from clap 3.0), therefore
becoming a deprecated project.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>