### PR TITLE
aya: Switch (again) from crates.io to git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["{{project-name}}", "{{project-name}}-common", "xtask"]
+
+[patch.crates-io]
+aya = { git = "https://github.com/aya-rs/aya", branch = "main" }

--- a/{{project-name}}-common/Cargo.toml
+++ b/{{project-name}}-common/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 user = [ "aya" ]
 
 [dependencies]
-aya = { version = "0.10", optional=true }
+aya = { git = "https://github.com/aya-rs/aya", branch = "main", optional=true }
 
 [lib]
 path = "src/lib.rs"

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = "0.10"
+aya = { git = "https://github.com/aya-rs/aya", branch = "main" }
 aya-log = "0.1"
 {{project-name}}-common = { path = "../{{project-name}}-common", features=["user"] }
 anyhow = "1.0.42"


### PR DESCRIPTION
This time we need to switch to git again, because of this unreleased
change:

aya-rs/aya@d1f22151935edebed13e0baaa04f25a96ddb30f0

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>