### PR TITLE
Add cgroup_sysctl template for BPF_PROG_TYPE_CGROUP_SYSCTL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - xdp
           - classifier
           - cgroup_skb
+          - cgroup_sysctl
           - tracepoint
           - lsm
           - tp_btf

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -18,6 +18,7 @@ choices = [
     "xdp",
     "classifier",
     "cgroup_skb",
+    "cgroup_sysctl",
     "tracepoint",
     "lsm",
     "tp_btf"

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -284,6 +284,25 @@ use aya_bpf::{
 pub fn {{crate_name}}(_ctx: SkBuffContext) -> i64 {
     return 0
 }
+{%- when "cgroup_sysctl" %}
+use aya_bpf::{
+    macros::cgroup_sysctl,
+    programs::SysctlContext,
+};
+use aya_log_ebpf::info;
+
+#[cgroup_sysctl(name="{{crate_name}}")]
+pub fn {{crate_name}}(ctx: SysctlContext) -> i32 {
+    match unsafe { try_{{crate_name}}(ctx) } {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+unsafe fn try_{{crate_name}}(ctx: SysctlContext) -> Result<i32, i32> {
+    info!(&ctx, "sysctl operation called");
+    Ok(0)
+}
 {%- endcase %}
 
 #[panic_handler]


### PR DESCRIPTION
Since https://github.com/aya-rs/aya/pull/256 supports `BPF_PROG_TYPE_CGROUP_SYSCTL`,
this patch adds cgroup_sysctl template.