### PR TITLE
Add cgroup_sockopt template for BPF_PROG_TYPE_CGROUP_SOCKOPT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - classifier
           - cgroup_skb
           - cgroup_sysctl
+          - cgroup_sockopt
           - tracepoint
           - lsm
           - tp_btf

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -19,6 +19,7 @@ choices = [
     "classifier",
     "cgroup_skb",
     "cgroup_sysctl",
+    "cgroup_sockopt",
     "tracepoint",
     "lsm",
     "tp_btf"
@@ -45,6 +46,11 @@ prompt = "Function name to attach the (u|uret)probe? (e.g getaddrinfo)"
 type = "string"
 prompt = "Attach direction?"
 choices = [ "Ingress", "Egress" ]
+
+[conditional.'program_type == "cgroup_sockopt"'.placeholders.sockopt_target]
+type = "string"
+prompt = "Which socket option?"
+choices = [ "getsockopt", "setsockopt" ]
 
 [conditional.'program_type == "sk_msg"'.placeholders.sock_map]
 type = "string"

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,9 @@ case "$PROG_TYPE" in
     "tp_btf")
 	    ADDITIONAL_ARGS="-d tracepoint_name=net_dev_queue"
         ;;
+    "cgroup_sockopt")
+	    ADDITIONAL_ARGS="-d sockopt_target=getsockopt"
+        ;;
     *)
         ADDITIONAL_ARGS=''
 esac

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -303,6 +303,25 @@ unsafe fn try_{{crate_name}}(ctx: SysctlContext) -> Result<i32, i32> {
     info!(&ctx, "sysctl operation called");
     Ok(0)
 }
+{%- when "cgroup_sockopt" %}
+use aya_bpf::{
+    macros::cgroup_sockopt,
+    programs::SockoptContext,
+};
+use aya_log_ebpf::info;
+
+#[cgroup_sockopt({{sockopt_target}},name="{{crate_name}}")]
+pub fn {{crate_name}}(ctx: SockoptContext) -> i32 {
+    match unsafe { try_{{crate_name}}(ctx) } {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+unsafe fn try_{{crate_name}}(ctx: SockoptContext) -> Result<i32, i32> {
+    info!(&ctx, "{{sockopt_target}} called");
+    Ok(0)
+}
 {%- endcase %}
 
 #[panic_handler]

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -47,7 +47,7 @@ struct Opt {
     {% if program_type == "xdp" or program_type == "classifier" -%}
     #[clap(short, long, default_value = "eth0")]
     iface: String,
-    {%- elsif program_type == "sock_ops" or program_type == "cgroup_skb" or program_type == "cgroup_sysctl" or "cgroup_sockopt" -%}
+    {%- elsif program_type == "sock_ops" or program_type == "cgroup_skb" or program_type == "cgroup_sysctl" or program_type == "cgroup_sockopt" -%}
     #[clap(short, long, default_value = "/sys/fs/cgroup/unified")]
     cgroup_path: String,
     {%- elsif program_type == "uprobe" or program_type == "uretprobe" -%}


### PR DESCRIPTION
Since https://github.com/aya-rs/aya/pull/268 supports `BPF_PROG_TYPE_CGROUP_SOCKOPT`,
this patch adds `cgroup_sockopt` template.
