### PR TITLE
Update dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["{{project-name}}", "{{project-name}}-common", "xtask"]
-
-[patch.crates-io]
-aya = { git = "https://github.com/aya-rs/aya", branch = "main" }

--- a/{{project-name}}-common/Cargo.toml
+++ b/{{project-name}}-common/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 user = [ "aya" ]
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", branch = "main", optional=true }
+aya = { version = ">=0.11", optional=true }
 
 [lib]
 path = "src/lib.rs"

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya = { version = ">=0.11", features=["async_tokio"] }
 aya-log = "0.1"
 {{project-name}}-common = { path = "../{{project-name}}-common", features=["user"] }
 anyhow = "1.0.42"


### PR DESCRIPTION
Use `aya = ">=0.10.7,<1.0"` and therefore the Aya version picked by
Cargo will be bounded by the latest version supported in
`aya-log = "0.1"`

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>