### PR TITLE
Add optional code for raising the RLIMIT_MEMLOCK

### DIFF
--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -11,7 +11,13 @@ aya-log = "0.1"
 anyhow = "1.0.42"
 clap = { version = "3.1", features = ["derive"] }
 {%- if program_type == "uprobe" %}
-libc = "0.2.102"
+libc = "0.2"
+{%- else %}
+# Kernels before 5.11 don't use cgroup accounting, so they might reach the
+# RLIMIT_MEMLOCK when creating maps. For that case, libc is needed when raising
+# RLIMIT_MEMLOCK to RLIM_INFINITY automatically.
+#
+# libc = "0.2"
 {%- endif %}
 log = "0.4"
 simplelog = "0.12"

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -82,6 +82,19 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;
+
+    // Kernels before 5.11 don't use cgroup accounting, so they might reach the
+    // RLIMIT_MEMLOCK when creating maps. For that case, this code can be used
+    // for raising RLIMIT_MEMLOCK to RLIM_INFINITY.
+    //
+    // let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &libc::rlimit {
+    //     rlim_cur: libc::RLIM_INFINITY,
+    //     rlim_max: libc::RLIM_INFINITY,
+    // }) };
+    // if ret != 0 {
+    //     return Err(anyhow::anyhow!("setrlimit failed"));
+    // }
+
     BpfLogger::init(&mut bpf)?;
     {% case program_type -%}
     {%- when "kprobe", "kretprobe" -%}


### PR DESCRIPTION
Kernels before 5.11 don't use cgroup accounting, so they might reach the
RLIMIT_MEMLOCK when creating maps. For that case, this change add a
commented code which can be used for raising RLIMIT_MEMLOCK to
RLIM_INFINITY.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>