### PR TITLE
ebpf: Update git repository URL for aya-log

### DIFF
--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 {{ project-name }}-common = { path = "../{{ project-name }}-common" }
 
 [[bin]]


### PR DESCRIPTION
aya-log was moved to the main aya repository, the old one is archived.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>