### PR TITLE
Use default-members in Cargo workspace

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,30 @@
 [alias]
 xtask = "run --package xtask --"
+
+# this should migrate to cargo per-target profiles when it is implemented
+
+[target.bpfel-unknown-none]
+rustflags = [
+    "-C", "panic=abort",
+    "-C", "lto=yes",
+    "-C", "embed-bitcode=yes",
+    "-C", "debuginfo=2",
+    "-C", "opt-level=3",
+    "-C", "codegen-units=1",
+    "-C", "debug-assertions=no",
+    "-C", "overflow-checks=no",
+    "-C", "incremental=no",
+]
+
+[target.bpfeb-unknown-none]
+rustflags = [
+    "-C", "panic=abort",
+    "-C", "lto=yes",
+    "-C", "embed-bitcode=yes",
+    "-C", "debuginfo=2",
+    "-C", "opt-level=3",
+    "-C", "codegen-units=1",
+    "-C", "debug-assertions=no",
+    "-C", "overflow-checks=no",
+    "-C", "incremental=no",
+]

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,3 +1,4 @@
 {
-  "rust-analyzer.linkedProjects": ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]
+  "rust-analyzer.checkOnSave.allTargets": false,
+  "rust-analyzer.checkOnSave.command": "clippy"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "rust-analyzer.linkedProjects": ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]
+  "rust-analyzer.checkOnSave.allTargets": false,
+  "rust-analyzer.checkOnSave.command": "clippy"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
-members = ["{{project-name}}", "{{project-name}}-common", "xtask"]
+members = ["{{project-name}}", "{{project-name}}-ebpf", "{{project-name}}-common", "xtask"]
+default-members = ["{{project-name}}", "{{project-name}}-common", "xtask"]

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -58,7 +58,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     args.append(&mut run_args);
 
     // spawn the command
-    let err = Command::new(args.get(0).expect("No first argument"))
+    let err = Command::new(args.first().expect("No first argument"))
         .args(args.iter().skip(1))
         .exec();
 

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -11,22 +11,3 @@ aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 [[bin]]
 name = "{{ project-name }}"
 path = "src/main.rs"
-
-[profile.dev]
-opt-level = 3
-debug = false
-debug-assertions = false
-overflow-checks = false
-lto = true
-panic = "abort"
-incremental = false
-codegen-units = 1
-rpath = false
-
-[profile.release]
-lto = true
-panic = "abort"
-codegen-units = 1
-
-[workspace]
-members = []


### PR DESCRIPTION
Adds bpf code to the workspace and is excluded by default.
This allows for all deps to be managed in Cargo.lock and for cargo
update to work as expected from the root.
Similarly, rustfmt and clippy can operate on the whole workspace.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>