### PR TITLE
ebpf: Change `static mut` to `static` in map declaration

### DIFF
--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -145,7 +145,7 @@ use aya_log_ebpf::info;
 use {{crate_name}}_common::SockKey;
 
 #[map(name="{{sock_map}}")]
-static mut {{sock_map}}: SockHash<SockKey> = SockHash::<SockKey>::with_max_entries(1024, 0);
+static {{sock_map}}: SockHash<SockKey> = SockHash::<SockKey>::with_max_entries(1024, 0);
 
 #[sk_msg(name="{{crate_name}}")]
 pub fn {{crate_name}}(ctx: SkMsgContext) -> u32 {


### PR DESCRIPTION
Maps are using UnsafeCell for interior mutability, therefore `static mut` is not needed anymore.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>