### PR TITLE
fix: enable info logging for xtask run

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -60,6 +60,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // spawn the command
     let err = Command::new(args.get(0).expect("No first argument"))
         .args(args.iter().skip(1))
+        .env("RUST_LOG", "info")
         .exec();
 
     // we shouldn't get here unless the command failed to spawn


### PR DESCRIPTION
I noticed that the default template doesn't enable the logging level necessary to see `info!()` output when running `cargo xtask run`, the result of which was that the output provided by the template (for instance when building an xdp program) wasn't displaying which could be confusing for new users. This PR enables info logging at the template level so that future projects built from this template will have logging on by default when running `cargo xtask run` after initial scaffolding.