### PR TITLE
readme: Mention `RUST_LOG` env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ cargo build
 ## Run
 
 ```bash
-cargo xtask run
+RUST_LOG=info cargo xtask run
 ```


### PR DESCRIPTION
The default log level of env_logger is `error`. We are using `info!` in the template, so let's suggest running the example with `RUST_LOG=info`.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>