### PR TITLE
Fix clippy issues in the generated code.

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 use clap::Parser;
 
@@ -55,7 +54,7 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
         args.push("--release")
     }
     let status = Command::new("cargo")
-        .current_dir(&dir)
+        .current_dir(dir)
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     };
 
     if let Err(e) = ret {
-        eprintln!("{:#}", e);
+        eprintln!("{e:#}");
         exit(1);
     }
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -47,7 +47,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
 
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{}/{{project-name}}", profile);
+    let bin_path = format!("target/{profile}/{{project-name}}");
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();
@@ -58,7 +58,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     args.append(&mut run_args);
 
     // spawn the command
-    let err = Command::new(args.get(0).expect("No first argument"))
+    let err = Command::new(args.first().expect("No first argument"))
         .args(args.iter().skip(1))
         .exec();
 

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -41,6 +41,9 @@ use clap::Parser;
 use log::{info, warn};
 use tokio::signal;
 
+{% case program_type %}
+{%- when
+    "xdp", "classifier", "sock_ops", "cgroup_skb", "cgroup_sysctl", "cgroup_sockopt", "uprobe", "uretprobe" -%}
 #[derive(Debug, Parser)]
 struct Opt {
     {% if program_type == "xdp" or program_type == "classifier" -%}
@@ -54,10 +57,16 @@ struct Opt {
     pid: Option<i32>
     {%- endif %}
 }
+{%- endcase %}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    {% case program_type %}
+    {%- when
+        "xdp", "classifier", "sock_ops", "cgroup_skb", "cgroup_sysctl", "cgroup_sockopt", "uprobe", "uretprobe" -%}
     let opt = Opt::parse();
+
+    {%- endcase %}
 
     env_logger::init();
 


### PR DESCRIPTION
Fix template so that the generated code would not have any clippy issues (per `cargo +nightly clippy`).
Add template conditionals on the program_type to avoid a warning about unused 'opt' variable.

Fixes #66. 

References:
* https://cargo-generate.github.io/cargo-generate/templates
* https://shopify.github.io/liquid/basics/introduction/
* https://github.com/topics/cargo-generate