### PR TITLE
Add toolchain parameter to xtask

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ cargo xtask build-ebpf
 ```
 
 To perform a release build you can use the `--release` flag.
-You may also change the target architecture with the `--target` flag
+You may also change the target architecture with the `--target` flag.
+If you require a specific (nightly) version of the toolchain, you can use the `--toolchain` flag.
 
 ## Build Userspace
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cargo xtask build-ebpf
 
 To perform a release build you can use the `--release` flag.
 You may also change the target architecture with the `--target` flag.
-If you require a specific (nightly) version of the toolchain, you can use the `--toolchain` flag.
+If you require a specific version of the toolchain, you can use the `--toolchain` flag (only nightly toolchains are supported).
 
 ## Build Userspace
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cargo xtask build-ebpf
 
 To perform a release build you can use the `--release` flag.
 You may also change the target architecture with the `--target` flag.
-If you require a specific version of the toolchain, you can use the `--toolchain` flag (only nightly toolchains are supported).
+If you require a specific version of the toolchain for the BPF program, you can use the `--bpf_toolchain` flag (only nightly toolchains are supported).
 
 ## Build Userspace
 

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -34,7 +34,7 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Set the rust toolchain
+    /// Set the rust toolchain (only nightly toolchains are supported)
     #[clap(default_value = "+nightly", long)]
     pub toolchain: String,
     /// Build the release target

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -34,6 +34,9 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
+    /// Set the rust toolchain
+    #[clap(default_value = "+nightly", long)]
+    pub toolchain: String,
     /// Build the release target
     #[clap(long)]
     pub release: bool,
@@ -43,7 +46,7 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
+        opts.toolchain.as_str(),
         "build",
         "--verbose",
         target.as_str(),

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -34,9 +34,9 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Set the rust toolchain (only nightly toolchains are supported)
+    /// Set the rust toolchain for the BPF program (only nightly toolchains are supported)
     #[clap(default_value = "+nightly", long)]
-    pub toolchain: String,
+    pub bpf_toolchain: String,
     /// Build the release target
     #[clap(long)]
     pub release: bool,
@@ -45,13 +45,13 @@ pub struct Options {
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
-    let toolchain = if opts.toolchain.starts_with('+') {
-        opts.toolchain
+    let bpf_toolchain = if opts.bpf_toolchain.starts_with('+') {
+        opts.bpf_toolchain
     }  else {
-        format!("+{}", opts.toolchain)
+        format!("+{}", opts.bpf_toolchain)
     };
     let mut args = vec![
-        toolchain.as_str(),
+        bpf_toolchain.as_str(),
         "build",
         "--verbose",
         target.as_str(),

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -36,7 +36,7 @@ pub struct Options {
     pub target: Architecture,
     /// Set the rust toolchain for the BPF program (only nightly toolchains are supported)
     #[clap(default_value = "+nightly", long)]
-    pub bpf_toolchain: String,
+    pub toolchain: String,
     /// Build the release target
     #[clap(long)]
     pub release: bool,
@@ -45,13 +45,13 @@ pub struct Options {
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
-    let bpf_toolchain = if opts.bpf_toolchain.starts_with('+') {
-        opts.bpf_toolchain
+    let toolchain = if opts.toolchain.starts_with('+') {
+        opts.toolchain
     }  else {
-        format!("+{}", opts.bpf_toolchain)
+        format!("+{}", opts.toolchain)
     };
     let mut args = vec![
-        bpf_toolchain.as_str(),
+        toolchain.as_str(),
         "build",
         "--verbose",
         target.as_str(),

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -45,8 +45,13 @@ pub struct Options {
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
+    let toolchain = if opts.toolchain.starts_with('+') {
+        opts.toolchain
+    }  else {
+        format!("+{}", opts.toolchain)
+    };
     let mut args = vec![
-        opts.toolchain.as_str(),
+        toolchain.as_str(),
         "build",
         "--verbose",
         target.as_str(),

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -19,6 +19,9 @@ pub struct Options {
     /// Arguments to pass to your application
     #[clap(name = "args", last = true)]
     pub run_args: Vec<String>,
+    /// Set the rust toolchain
+    #[clap(default_value = "+nightly", long)]
+    pub toolchain: String,
 }
 
 /// Build the project
@@ -41,6 +44,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
         release: opts.release,
+        toolchain: opts.toolchain.clone(),
     })
     .context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace application")?;

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -19,9 +19,9 @@ pub struct Options {
     /// Arguments to pass to your application
     #[clap(name = "args", last = true)]
     pub run_args: Vec<String>,
-    /// Set the rust toolchain (only nightly toolchains are supported)
+    /// Set the rust toolchain for the BPF program (only nightly toolchains are supported)
     #[clap(default_value = "+nightly", long)]
-    pub toolchain: String,
+    pub bpf_toolchain: String,
 }
 
 /// Build the project
@@ -44,7 +44,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
         release: opts.release,
-        toolchain: opts.toolchain.clone(),
+        bpf_toolchain: opts.bpf_toolchain.clone(),
     })
     .context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace application")?;

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -19,7 +19,7 @@ pub struct Options {
     /// Arguments to pass to your application
     #[clap(name = "args", last = true)]
     pub run_args: Vec<String>,
-    /// Set the rust toolchain
+    /// Set the rust toolchain (only nightly toolchains are supported)
     #[clap(default_value = "+nightly", long)]
     pub toolchain: String,
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -10,6 +10,9 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub bpf_target: Architecture,
+    /// Set the rust toolchain for the BPF program (only nightly toolchains are supported)
+    #[clap(default_value = "+nightly", long)]
+    pub bpf_toolchain: String,
     /// Build and run the release target
     #[clap(long)]
     pub release: bool,
@@ -19,9 +22,6 @@ pub struct Options {
     /// Arguments to pass to your application
     #[clap(name = "args", last = true)]
     pub run_args: Vec<String>,
-    /// Set the rust toolchain for the BPF program (only nightly toolchains are supported)
-    #[clap(default_value = "+nightly", long)]
-    pub bpf_toolchain: String,
 }
 
 /// Build the project
@@ -44,7 +44,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
         release: opts.release,
-        bpf_toolchain: opts.bpf_toolchain.clone(),
+        toolchain: opts.bpf_toolchain.clone(),
     })
     .context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace application")?;


### PR DESCRIPTION
Hi,

with the build issue with currenty nightly for the BPF target (https://github.com/rust-lang/rust/issues/106795), I thought it would be helpful to add a toolchain parameter to xtask. Especially because xtask does currently not follow the normal toolchain override mechanisms (https://rust-lang.github.io/rustup/overrides.html).