### PR TITLE
Honor rust-toolchain.toml file in xtask, remove env vars with CARGO/RUST prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install latest nightly
+      - name: Install latest nightly (pinned to nightly-2023-01-10, https://github.com/aya-rs/aya/issues/490)
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-01-10
           components: rust-src
 
       - name: Install bpf-linker
-        run: cargo +nightly install bpf-linker
+        run: cargo install bpf-linker
 
       - name: Install Cargo Generate
         run: cargo install --git https://github.com/cargo-generate/cargo-generate cargo-generate

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, path::PathBuf, process::Command};
+use std::{path::PathBuf, process::Command};
 
 use clap::Parser;
 
@@ -54,16 +54,12 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     }
 
     // Command::new creates a child process which inherits all env variables. This means env
-    // vars set by the cargo xtask command are also inherited. All env vars related to the
-    // cargo xtask invocation are removed.
-    let filtered_env: HashMap<String, String> = env::vars()
-        .filter(|&(ref k, _)| !k.starts_with("CARGO") && !k.starts_with("RUST"))
-        .collect();
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
 
     let status = Command::new("cargo")
         .current_dir(dir)
-        .env_clear()
-        .envs(&filtered_env)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/{{project-name}}-ebpf/rust-toolchain.toml
+++ b/{{project-name}}-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"


### PR DESCRIPTION
Command::new creates a child process which inherits all env variables. This means env vars set by the cargo xtask command are also inherited. This leads to the `rust-toolchain.toml` file in the -ebpf folder not being honored. To fix this, all env vars starting with `CARGO` or `RUST` are removed before the child process is created.

This approach also means the run/build-ebpf tasks cannot be influenced by env vars set when using `cargo xtask run/build-ebpf`. I think this is a lesser issue than hardcoding nightly or the approach in #69.