### PR TITLE
Add rust-src to -ebpf components

### DIFF
--- a/{{project-name}}-ebpf/rust-toolchain.toml
+++ b/{{project-name}}-ebpf/rust-toolchain.toml
@@ -1,3 +1,5 @@
 [toolchain]
 channel="nightly-2023-01-10"
+# The source code of rustc, provided by the rust-src component, is needed for
+# building eBPF programs.
 components = [ "rustc", "rust-std", "cargo", "rust-docs", "rustfmt", "clippy", "rust-src" ]

--- a/{{project-name}}-ebpf/rust-toolchain.toml
+++ b/{{project-name}}-ebpf/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel="nightly-2023-01-10"
+components = [ "rustc", "rust-std", "cargo", "rust-docs", "rustfmt", "clippy", "rust-src" ]


### PR DESCRIPTION
Profiles here: https://rust-lang.github.io/rustup/concepts/profiles.html

Detailed here: https://rust-lang.github.io/rustup/concepts/components.html

I've copied the minimal, default, then added `rust-src`.

This means that you don't need to manually add it via `rustup toolchain install nightly-2023-01-10 --component rust-src`.