### PR TITLE
cargo-generate: add perf_event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,15 @@ jobs:
           - socket_filter
           - sk_msg
           - xdp
-          - classifier
           - cgroup_skb
-          - cgroup_sysctl
           - cgroup_sockopt
-          - tracepoint
+          - cgroup_sysctl
+          - classifier
           - lsm
-          - tp_btf
+          - perf_event
           - raw_tracepoint
+          - tp_btf
+          - tracepoint
 
     steps:
       - uses: actions/checkout@v2

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -15,6 +15,7 @@ choices = [
     "kprobe",
     "kretprobe",
     "lsm",
+    "perf_event",
     "raw_tracepoint",
     "sk_msg",
     "sock_ops",


### PR DESCRIPTION
This adds `perf_event` program type as a template entry.
The new entry comes with a skeleton example which register scheduled events on each CPU at 1 HZ, triggered by the kernel (based on clock ticks).
The corresponding BPF logic logs each event, and can identify kernel tasks from userland processes.

Closes: https://github.com/aya-rs/aya-template/issues/7