### PR TITLE
update anyhow, clap, and tokio

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -7,17 +7,17 @@ publish = false
 [dependencies]
 aya = { version = ">=0.11", features=["async_tokio"] }
 {% if program_types_with_opts contains program_type -%}
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }
 {% endif -%}
 aya-log = "0.1"
 {{project-name}}-common = { path = "../{{project-name}}-common", features=["user"] }
-anyhow = "1.0.42"
+anyhow = "1.0.68"
 env_logger = "0.10"
 {%- if program_type == "uprobe" %}
 libc = "0.2"
 {%- endif %}
 log = "0.4"
-tokio = { version = "1.23", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 
 [[bin]]
 name = "{{project-name}}"


### PR DESCRIPTION
PR upgrades anyhow, clap, and tokio to the latest versions.

Currently running `cargo upgrade -i` in a generated project produces:
```
    Checking tctest's dependencies
name   old req compatible latest new req
====   ======= ========== ====== =======
clap   4.0     4.1.4      4.1.4  4.1
anyhow 1.0.42  1.0.68     1.0.68 1.0.68
tokio  1.23    1.24.2     1.24.2 1.24
    Checking tctest-common's dependencies
    Checking xtask's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.0     4.1.4      4.1.4  4.1
   Upgrading recursive dependencies
```