### PR TITLE
Fix uprobe programs and VSCode spacing

### DIFF
--- a/{{project-name}}-common/Cargo.toml
+++ b/{{project-name}}-common/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [features]
 default = []
-user = [ "aya" ]
+user = ["aya"]
 
 [dependencies]
-aya = { version = ">=0.11", optional=true }
+aya = { version = ">=0.11", optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -2,13 +2,10 @@
 #![no_main]
 {% case program_type -%}
 {%- when "kprobe" %}
-use aya_bpf::{
-    macros::kprobe,
-    programs::ProbeContext,
-};
+use aya_bpf::{macros::kprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
-#[kprobe(name="{{crate_name}}")]
+#[kprobe(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: ProbeContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -21,13 +18,10 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "kretprobe" %}
-use aya_bpf::{
-    macros::kretprobe,
-    programs::ProbeContext,
-};
+use aya_bpf::{macros::kretprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
-#[kretprobe(name="{{crate_name}}")]
+#[kretprobe(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: ProbeContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -160,14 +154,10 @@ fn try_{{crate_name}}(ctx: SkMsgContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "xdp" %}
-use aya_bpf::{
-    bindings::xdp_action,
-    macros::xdp,
-    programs::XdpContext,
-};
+use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 use aya_log_ebpf::info;
 
-#[xdp(name="{{crate_name}}")]
+#[xdp(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: XdpContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -180,13 +170,10 @@ fn try_{{crate_name}}(ctx: XdpContext) -> Result<u32, u32> {
     Ok(xdp_action::XDP_PASS)
 }
 {%- when "classifier" %}
-use aya_bpf::{
-    macros::classifier,
-    programs::TcContext,
-};
+use aya_bpf::{macros::classifier, programs::TcContext};
 use aya_log_ebpf::info;
 
-#[classifier(name="{{crate_name}}")]
+#[classifier(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: TcContext) -> i32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -224,7 +211,7 @@ use aya_bpf::{
 };
 use aya_log_ebpf::info;
 
-#[tracepoint(name="{{crate_name}}")]
+#[tracepoint(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: TracePointContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -243,7 +230,7 @@ use aya_bpf::{
 };
 use aya_log_ebpf::info;
 
-#[lsm(name="{{lsm_hook}}")]
+#[lsm(name = "{{lsm_hook}}")]
 pub fn {{lsm_hook}}(ctx: LsmContext) -> i32 {
     match try_{{lsm_hook}}(ctx) {
         Ok(ret) => ret,
@@ -262,7 +249,7 @@ use aya_bpf::{
 };
 use aya_log_ebpf::info;
 
-#[btf_tracepoint(name="{{tracepoint_name}}")]
+#[btf_tracepoint(name = "{{tracepoint_name}}")]
 pub fn {{tracepoint_name}}(ctx: BtfTracePointContext) -> i32 {
     match try_{{tracepoint_name}}(ctx) {
         Ok(ret) => ret,
@@ -280,7 +267,7 @@ use aya_bpf::{
     programs::SkBuffContext,
 };
 
-#[socket_filter(name="{{crate_name}}")]
+#[socket_filter(name = "{{crate_name}}")]
 pub fn {{crate_name}}(_ctx: SkBuffContext) -> i64 {
     return 0
 }
@@ -291,7 +278,7 @@ use aya_bpf::{
 };
 use aya_log_ebpf::info;
 
-#[cgroup_sysctl(name="{{crate_name}}")]
+#[cgroup_sysctl(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: SysctlContext) -> i32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -304,13 +291,10 @@ fn try_{{crate_name}}(ctx: SysctlContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "cgroup_sockopt" %}
-use aya_bpf::{
-    macros::cgroup_sockopt,
-    programs::SockoptContext,
-};
+use aya_bpf::{macros::cgroup_sockopt, programs::SockoptContext};
 use aya_log_ebpf::info;
 
-#[cgroup_sockopt({{sockopt_target}},name="{{crate_name}}")]
+#[cgroup_sockopt({{sockopt_target}}, name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: SockoptContext) -> i32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -323,13 +307,10 @@ fn try_{{crate_name}}(ctx: SockoptContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "raw_tracepoint" %}
-use aya_bpf::{
-    macros::raw_tracepoint,
-    programs::RawTracePointContext,
-};
+use aya_bpf::{macros::raw_tracepoint, programs::RawTracePointContext};
 use aya_log_ebpf::info;
 
-#[raw_tracepoint(name="{{crate_name}}")]
+#[raw_tracepoint(name = "{{crate_name}}")]
 pub fn {{crate_name}}(ctx: RawTracePointContext) -> i32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -343,10 +324,7 @@ fn try_{{crate_name}}(ctx: RawTracePointContext) -> Result<i32, i32> {
 }
 {%- when "perf_event" %}
 use aya_bpf::{
-    helpers::bpf_get_smp_processor_id,
-    macros::perf_event,
-    programs::PerfEventContext,
-    BpfContext,
+    helpers::bpf_get_smp_processor_id, macros::perf_event, programs::PerfEventContext, BpfContext,
 };
 use aya_log_ebpf::info;
 
@@ -361,8 +339,14 @@ pub fn {{crate_name}}(ctx: PerfEventContext) -> u32 {
 fn try_{{crate_name}}(ctx: PerfEventContext) -> Result<u32, u32> {
     let cpu = unsafe { bpf_get_smp_processor_id() };
     match ctx.pid() {
-        0 => info!(&ctx, "perf_event '{{crate_name}}' triggered on CPU {}, running a kernel task", cpu),
-        pid => info!(&ctx, "perf_event '{{crate_name}}' triggered on CPU {}, running PID {}", cpu, pid),
+        0 => info!(
+            &ctx,
+            "perf_event 'perftest' triggered on CPU {}, running a kernel task", cpu
+        ),
+        pid => info!(
+            &ctx,
+            "perf_event 'perftest' triggered on CPU {}, running PID {}", cpu, pid
+        ),
     }
 
     Ok(0)

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -6,16 +6,14 @@ publish = false
 
 [dependencies]
 aya = { version = ">=0.11", features=["async_tokio"] }
+aya-log = "0.1"
 {% if program_types_with_opts contains program_type -%}
 clap = { version = "4.1", features = ["derive"] }
 {% endif -%}
-aya-log = "0.1"
-{{project-name}}-common = { path = "../{{project-name}}-common", features=["user"] }
+{{project-name}}-common = { path = "../{{project-name}}-common", features = ["user"] }
 anyhow = "1.0.68"
 env_logger = "0.10"
-{%- if program_type == "uprobe" %}
 libc = "0.2"
-{%- endif %}
 log = "0.4"
 tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -13,7 +13,9 @@ clap = { version = "4.1", features = ["derive"] }
 {{project-name}}-common = { path = "../{{project-name}}-common", features = ["user"] }
 anyhow = "1.0.68"
 env_logger = "0.10"
+{%- if program_type == "uprobe" %}
 libc = "0.2"
+{%- endif %}
 log = "0.4"
 tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -59,7 +59,7 @@ struct Opt {
     cgroup_path: String,
 {% elsif program_type == "uprobe" or program_type == "uretprobe" %}
     #[clap(short, long)]
-    pid: Option<i32>
+    pid: Option<i32>,
 {% endif -%}
 }
 
@@ -105,7 +105,7 @@ async fn main() -> Result<(), anyhow::Error> {
     {%- when "uprobe", "uretprobe" -%}
     let program: &mut UProbe = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     program.load()?;
-    program.attach(Some("{{uprobe_fn_name}}"), 0, "{{uprobe_target}}", opt.pid.try_into()?)?;
+    program.attach(Some("{{uprobe_fn_name}}"), 0, "{{uprobe_target}}", opt.pid)?;
     {%- when "sock_ops" -%}
     let program: &mut SockOps = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     let cgroup = std::fs::File::open(opt.cgroup_path)?;


### PR DESCRIPTION
PR fixes the generated uprobe programs so that they wouldn't have any fmt or clippy issues, and adjusts the spacing so that the generated programs don't change in VSCode (default settings) on save.