### PR TITLE
Remove unix-specific executor in xtask

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -1,4 +1,4 @@
-use std::{os::unix::process::CommandExt, process::Command};
+use std::process::Command;
 
 use anyhow::Context as _;
 use clap::Parser;
@@ -57,11 +57,12 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     args.push(bin_path.as_str());
     args.append(&mut run_args);
 
-    // spawn the command
-    let err = Command::new(args.first().expect("No first argument"))
+    // run the command
+    let status = Command::new(args.first().expect("No first argument"))
         .args(args.iter().skip(1))
-        .exec();
+        .status()
+        .expect("failed to run the command");
 
-    // we shouldn't get here unless the command failed to spawn
-    Err(anyhow::Error::from(err).context(format!("Failed to run `{}`", args.join(" "))))
+    assert!(status.success());
+    Ok(())
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -63,6 +63,8 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
         .status()
         .expect("failed to run the command");
 
-    assert!(status.success());
+    if !status.success() {
+        anyhow::bail!("Failed to run `{}`", args.join(" "));
+    }
     Ok(())
 }


### PR DESCRIPTION
Change unix-specific executor to generic one
to enable xtask working on Windows and eventually
be able to cross-compile on Windows.

Fixes #76.