### PR TITLE
change to 'rustup run nightly cargo'

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -43,6 +43,9 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("{{project-name}}-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
+        "run",
+        "nightly",
+        "cargo",
         "build",
         "--verbose",
         target.as_str(),
@@ -57,7 +60,7 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
     // so the rust-toolchain.toml file in the -ebpf folder is honored.
 
-    let status = Command::new("cargo")
+    let status = Command::new("rustup")
         .current_dir(dir)
         .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)


### PR DESCRIPTION
On Windows, running the cargo command doesn't "see" the rust-toolchain.toml file despite `current_dir(dir)`.  Using `rustup run nightly cargo` does work.