### PR TITLE
sync rustup nightly install directions with Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 1. Install a rust stable toolchain: `rustup install stable`
-1. Install a rust nightly toolchain: `rustup install nightly`
+1. Install a rust nightly toolchain with the rust-src component: `rustup toolchain install nightly --component rust-src`
 1. Install bpf-linker: `cargo install bpf-linker`
 
 ## Build eBPF


### PR DESCRIPTION
PR syncs the rustup nightly install instructions in the generated `README.md` with the Book <https://aya-rs.dev/book/start/development/#prerequisites>.