### PR TITLE
Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
 
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rust-src


### PR DESCRIPTION
See https://github.com/actions-rs/toolchain/issues/216; actions-rs seems
to be unmaintained.
