### PR TITLE
fix: fixes aya and aya-log version mismatch

### DIFF
--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { git="https://github.com/aya-rs/aya", features=["async_tokio"] }
-aya-log = { git="https://github.com/aya-rs/aya" }
+aya = { git = "https://github.com/aya-rs/aya", features = ["async_tokio"] }
+aya-log = { git = "https://github.com/aya-rs/aya" }
 {% if program_types_with_opts contains program_type -%}
 clap = { version = "4.1", features = ["derive"] }
 {% endif -%}

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features=["async_tokio"] }
-aya-log = "0.1"
+aya = { git="https://github.com/aya-rs/aya", features=["async_tokio"] }
+aya-log = { git="https://github.com/aya-rs/aya" }
 {% if program_types_with_opts contains program_type -%}
 clap = { version = "4.1", features = ["derive"] }
 {% endif -%}


### PR DESCRIPTION
Fixes aya and aya-log version mismatch between {{project-name}}-epbf and {{project-name}} crates.

Fixes https://github.com/aya-rs/aya/issues/565.