### PR TITLE
Remove redundant instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## Prerequisites
 
-1. Install a rust stable toolchain: `rustup install stable`
-1. Install a rust nightly toolchain with the rust-src component: `rustup toolchain install nightly --component rust-src`
 1. Install bpf-linker: `cargo install bpf-linker`
 
 ## Build eBPF


### PR DESCRIPTION
We just need to install bpf-linker; the rest of this is already encoded in rust-toolchain.toml.

Fixes #83.