### PR TITLE
Allow process to lock memory for eBPF resources.

### DIFF
--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -13,12 +13,9 @@ clap = { version = "4.1", features = ["derive"] }
 {{project-name}}-common = { path = "../{{project-name}}-common", features = ["user"] }
 anyhow = "1"
 env_logger = "0.10"
-{%- if program_type == "uprobe" %}
-libc = "0.2"
-{%- endif %}
 log = "0.4"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
-rlimit = "0.9.1"
+libc = "0.2"
 
 [[bin]]
 name = "{{project-name}}"

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 {%- endif %}
 log = "0.4"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+rlimit = "0.9.1"
 
 [[bin]]
 name = "{{project-name}}"

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -13,9 +13,9 @@ clap = { version = "4.1", features = ["derive"] }
 {{project-name}}-common = { path = "../{{project-name}}-common", features = ["user"] }
 anyhow = "1"
 env_logger = "0.10"
+libc = "0.2"
 log = "0.4"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
-libc = "0.2"
 
 [[bin]]
 name = "{{project-name}}"

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -72,12 +72,15 @@ async fn main() -> Result<(), anyhow::Error> {
 {% endif %}
     env_logger::init();
 
-    if !Resource::MEMLOCK
-        .set(rlimit::INFINITY, rlimit::INFINITY)
-        .is_ok()
-    {
+    let rlim = libc::rlimit{
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if !ret == 0{
         warn!("cannot remove mem lock");
     }
+
 
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -71,13 +71,14 @@ async fn main() -> Result<(), anyhow::Error> {
 {% endif %}
     env_logger::init();
 
-    let rlim = libc::rlimit{
+    // Allow current process to lock memory for eBPF resources.
+    let rlim = libc::rlimit {
         rlim_cur: libc::RLIM_INFINITY,
         rlim_max: libc::RLIM_INFINITY,
     };
     let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
-    if !ret == 0{
-        warn!("cannot remove mem lock");
+    if ret != 0 {
+        warn!("remove limit on locked memory failed, ret is: {}", ret);
     }
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -46,6 +46,7 @@ use aya_log::BpfLogger;
 use clap::Parser;
 {% endif -%}
 use log::{info, warn};
+use rlimit::Resource;
 use tokio::signal;
 
 {% if program_types_with_opts contains program_type -%}
@@ -70,6 +71,14 @@ async fn main() -> Result<(), anyhow::Error> {
     let opt = Opt::parse();
 {% endif %}
     env_logger::init();
+
+    if !Resource::MEMLOCK
+        .set(rlimit::INFINITY, rlimit::INFINITY)
+        .is_ok()
+    {
+        warn!("cannot remove mem lock");
+    }
+
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at
     // runtime. This approach is recommended for most real-world use cases. If you would

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
     if ret != 0 {
-        warn!("remove limit on locked memory failed, ret is: {}", ret);
+        debug!("remove limit on locked memory failed, ret is: {}", ret);
     }
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -81,7 +81,6 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
 
-
     // This will include your eBPF object file as raw bytes at compile-time and load it at
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -46,7 +46,6 @@ use aya_log::BpfLogger;
 use clap::Parser;
 {% endif -%}
 use log::{info, warn};
-use rlimit::Resource;
 use tokio::signal;
 
 {% if program_types_with_opts contains program_type -%}

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -45,7 +45,7 @@ use aya_log::BpfLogger;
 {% if program_types_with_opts contains program_type -%}
 use clap::Parser;
 {% endif -%}
-use log::{info, warn};
+use log::{info, warn, debug};
 use tokio::signal;
 
 {% if program_types_with_opts contains program_type -%}

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -71,7 +71,8 @@ async fn main() -> Result<(), anyhow::Error> {
 {% endif %}
     env_logger::init();
 
-    // Allow current process to lock memory for eBPF resources.
+    // Bump the memlock rlimit. This is needed for older kernels that don't use the
+    // new memcg based accounting, see https://lwn.net/Articles/837122/
     let rlim = libc::rlimit {
         rlim_cur: libc::RLIM_INFINITY,
         rlim_max: libc::RLIM_INFINITY,

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -80,7 +80,6 @@ async fn main() -> Result<(), anyhow::Error> {
         warn!("cannot remove mem lock");
     }
 
-
     // This will include your eBPF object file as raw bytes at compile-time and load it at
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can


### PR DESCRIPTION
To solve issue mentioned in https://github.com/aya-rs/aya/issues/609, add `memlock remove` handle.