### PR TITLE
ebpf: Always use `release` profile

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -34,9 +34,6 @@ pub struct Options {
     /// Set the endianness of the BPF target
     #[clap(default_value = "bpfel-unknown-none", long)]
     pub target: Architecture,
-    /// Build the release target
-    #[clap(long)]
-    pub release: bool,
 }
 
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
@@ -44,14 +41,12 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let target = format!("--target={}", opts.target);
     let mut args = vec![
         "build",
+        "--release",
         "--verbose",
         target.as_str(),
         "-Z",
         "build-std=core",
     ];
-    if opts.release {
-        args.push("--release")
-    }
 
     // Command::new creates a child process which inherits all env variables. This means env
     // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -40,7 +40,6 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // build our ebpf program followed by our application
     build_ebpf(BuildOptions {
         target: opts.bpf_target,
-        release: opts.release,
     })
     .context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace application")?;

--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -12,17 +12,6 @@ aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
 name = "{{ project-name }}"
 path = "src/main.rs"
 
-[profile.dev]
-opt-level = 3
-debug = false
-debug-assertions = false
-overflow-checks = false
-lto = true
-panic = "abort"
-incremental = false
-codegen-units = 1
-rpath = false
-
 [profile.release]
 lto = true
 panic = "abort"

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -86,11 +86,6 @@ async fn main() -> Result<(), anyhow::Error> {
     // runtime. This approach is recommended for most real-world use cases. If you would
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
-    #[cfg(debug_assertions)]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/{{project-name}}"
-    ))?;
-    #[cfg(not(debug_assertions))]
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;


### PR DESCRIPTION
Using `dev` profile, even after tuning flags (to make it identical with `release`) still causes problems and is confusing for people.

And even when we have BTF support in future, it'd be better and less confusing to set `debug=2` in `release` profile (because we would want debug info, but still keep the same opt-level and other options).