### PR TITLE
trivial: Update Cargo.toml template resolver = "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["xtask", "{{project-name}}", "{{project-name}}-common"]
+resolver = "2"


### PR DESCRIPTION
When we try to run `cargo xtask build-ebpf` etc. we get the warning about Workspace default resolver set to "1". Since all the projects will be 2021 Edition, adding 'resolver = "2"' in the root `Cargo.toml` template to avoid this warning.