### PR TITLE
Support rust-analyzer on helix editor

### DIFF
--- a/{{project-name}}-ebpf/.helix/config.toml
+++ b/{{project-name}}-ebpf/.helix/config.toml
@@ -1,0 +1,2 @@
+[editor]
+workspace-lsp-roots = []


### PR DESCRIPTION
This patch allows the helix editor to correctly initialize the rust-analyzer when opening a source file from {{project-name}}-ebpf.

To find the Cargo.toml the helix editor must be launched from the {{project-name}}-ebpf directory or provide the workspace path as follows:

hx -w <path to {{project-name}}-ebpf> [relative path in {{project-name}}-ebpf]

The patch was tested using helix version 23.10.