### PR TITLE
ebpf: use TC_ACT_PIPE in classifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["xtask", "{{project-name}}", "{{project-name}}-common"]

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -170,7 +170,7 @@ fn try_{{crate_name}}(ctx: XdpContext) -> Result<u32, u32> {
     Ok(xdp_action::XDP_PASS)
 }
 {%- when "classifier" %}
-use aya_ebpf::{macros::classifier, programs::TcContext};
+use aya_ebpf::{bindings::TC_ACT_PIPE, macros::classifier, programs::TcContext};
 use aya_log_ebpf::info;
 
 #[classifier]
@@ -183,7 +183,7 @@ pub fn {{crate_name}}(ctx: TcContext) -> i32 {
 
 fn try_{{crate_name}}(ctx: TcContext) -> Result<i32, i32> {
     info!(&ctx, "received a packet");
-    Ok(0)
+    Ok(TC_ACT_PIPE)
 }
 {%- when "cgroup_skb" %}
 use aya_ebpf::{


### PR DESCRIPTION
Demonstrate using the correct constant instead of a magic number.

Also set `resolver = "2"` at the workspace's Cargo.toml. This is the default resolver for the 2021 edition, but is a workspace-wide setting needs to be set manually in virtual workspaces. https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details