### PR TITLE
Rename Bpf -> Ebpf

### DIFF
--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aya-bpf = { git = "https://github.com/aya-rs/aya" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
 {{ project-name }}-common = { path = "../{{ project-name }}-common" }
 

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 {% case program_type -%}
 {%- when "kprobe" %}
-use aya_bpf::{macros::kprobe, programs::ProbeContext};
+use aya_ebpf::{macros::kprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
 #[kprobe]

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), anyhow::Error> {
         "../../target/bpfel-unknown-none/debug/{{project-name}}"
     ))?;
     #[cfg(not(debug_assertions))]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
+    let mut bpf = Ebpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;
     if let Err(e) = EbpfLogger::init(&mut bpf) {

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -39,8 +39,8 @@ use aya::programs::SocketFilter;
 {%- when "raw_tracepoint" -%}
 use aya::programs::RawTracePoint;
 {%- endcase %}
-use aya::{include_bytes_aligned, Bpf};
-use aya_log::BpfLogger;
+use aya::{include_bytes_aligned, Ebpf};
+use aya_log::EbpfLogger;
 {% if program_types_with_opts contains program_type -%}
 use clap::Parser;
 {% endif -%}
@@ -86,14 +86,14 @@ async fn main() -> Result<(), anyhow::Error> {
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
     #[cfg(debug_assertions)]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
+    let mut bpf = Ebpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/debug/{{project-name}}"
     ))?;
     #[cfg(not(debug_assertions))]
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;
-    if let Err(e) = BpfLogger::init(&mut bpf) {
+    if let Err(e) = EbpfLogger::init(&mut bpf) {
         // This can happen if you remove all log statements from your eBPF program.
         warn!("failed to initialize eBPF logger: {}", e);
     }


### PR DESCRIPTION
Because of https://github.com/aya-rs/aya/pull/528, the template is out of date and generates broken code.
The first commit fixes the broken dependency (`aya-ebpf`).
The second commit isn't strictly necessary since `Bpf`/`BpfLogger` still work, but they are deprecated.
Whether the variable `bpf` in `{{project-name}}/src/main.rs` should also be renamed to `ebpf` is a question of taste, so I left it out.