### PR TITLE
Rename aya-bpf to aya-ebpf.

### DIFF
--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aya-bpf = { git = "https://github.com/aya-rs/aya" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
 {{ project-name }}-common = { path = "../{{ project-name }}-common" }
 

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -18,7 +18,7 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "kretprobe" %}
-use aya_bpf::{macros::kretprobe, programs::ProbeContext};
+use aya_ebpf::{macros::kretprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
 #[kretprobe]
@@ -34,7 +34,7 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "fentry" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::fentry,
     programs::FEntryContext,
 };
@@ -53,7 +53,7 @@ fn try_{{crate_name}}(ctx: FEntryContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "fexit" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::fexit,
     programs::FExitContext,
 };
@@ -72,7 +72,7 @@ fn try_{{crate_name}}(ctx: FExitContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "uprobe" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::uprobe,
     programs::ProbeContext,
 };
@@ -91,7 +91,7 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "uretprobe" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::uretprobe,
     programs::ProbeContext,
 };
@@ -110,7 +110,7 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "sock_ops" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::sock_ops,
     programs::SockOpsContext,
 };
@@ -129,7 +129,7 @@ fn try_{{crate_name}}(ctx: SockOpsContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "sk_msg" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::{map, sk_msg},
     maps::SockHash,
     programs::SkMsgContext,
@@ -154,7 +154,7 @@ fn try_{{crate_name}}(ctx: SkMsgContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "xdp" %}
-use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
+use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 use aya_log_ebpf::info;
 
 #[xdp]
@@ -170,7 +170,7 @@ fn try_{{crate_name}}(ctx: XdpContext) -> Result<u32, u32> {
     Ok(xdp_action::XDP_PASS)
 }
 {%- when "classifier" %}
-use aya_bpf::{macros::classifier, programs::TcContext};
+use aya_ebpf::{macros::classifier, programs::TcContext};
 use aya_log_ebpf::info;
 
 #[classifier]
@@ -186,7 +186,7 @@ fn try_{{crate_name}}(ctx: TcContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "cgroup_skb" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::cgroup_skb,
     programs::SkBuffContext,
 };
@@ -205,7 +205,7 @@ fn try_{{crate_name}}(ctx: SkBuffContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "tracepoint" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::tracepoint,
     programs::TracePointContext,
 };
@@ -224,7 +224,7 @@ fn try_{{crate_name}}(ctx: TracePointContext) -> Result<u32, u32> {
     Ok(0)
 }
 {%- when "lsm" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::lsm,
     programs::LsmContext,
 };
@@ -243,7 +243,7 @@ fn try_{{lsm_hook}}(ctx: LsmContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "tp_btf" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::btf_tracepoint,
     programs::BtfTracePointContext,
 };
@@ -262,7 +262,7 @@ fn try_{{tracepoint_name}}(ctx: BtfTracePointContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "socket_filter" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::socket_filter,
     programs::SkBuffContext,
 };
@@ -272,7 +272,7 @@ pub fn {{crate_name}}(_ctx: SkBuffContext) -> i64 {
     return 0
 }
 {%- when "cgroup_sysctl" %}
-use aya_bpf::{
+use aya_ebpf::{
     macros::cgroup_sysctl,
     programs::SysctlContext,
 };
@@ -291,7 +291,7 @@ fn try_{{crate_name}}(ctx: SysctlContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "cgroup_sockopt" %}
-use aya_bpf::{macros::cgroup_sockopt, programs::SockoptContext};
+use aya_ebpf::{macros::cgroup_sockopt, programs::SockoptContext};
 use aya_log_ebpf::info;
 
 #[cgroup_sockopt({{sockopt_target}})]
@@ -307,7 +307,7 @@ fn try_{{crate_name}}(ctx: SockoptContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "raw_tracepoint" %}
-use aya_bpf::{macros::raw_tracepoint, programs::RawTracePointContext};
+use aya_ebpf::{macros::raw_tracepoint, programs::RawTracePointContext};
 use aya_log_ebpf::info;
 
 #[raw_tracepoint(tracepoint="{{tracepoint_name}}")]
@@ -323,7 +323,7 @@ fn try_{{crate_name}}(ctx: RawTracePointContext) -> Result<i32, i32> {
     Ok(0)
 }
 {%- when "perf_event" %}
-use aya_bpf::{
+use aya_ebpf::{
     helpers::bpf_get_smp_processor_id, macros::perf_event, programs::PerfEventContext, BpfContext,
 };
 use aya_log_ebpf::info;

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -324,7 +324,7 @@ fn try_{{crate_name}}(ctx: RawTracePointContext) -> Result<i32, i32> {
 }
 {%- when "perf_event" %}
 use aya_ebpf::{
-    helpers::bpf_get_smp_processor_id, macros::perf_event, programs::PerfEventContext, BpfContext,
+    helpers::bpf_get_smp_processor_id, macros::perf_event, programs::PerfEventContext, EbpfContext,
 };
 use aya_log_ebpf::info;
 

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 {% case program_type -%}
 {%- when "kprobe" %}
-use aya_bpf::{macros::kprobe, programs::ProbeContext};
+use aya_ebpf::{macros::kprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
 #[kprobe]

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -39,8 +39,8 @@ use aya::programs::SocketFilter;
 {%- when "raw_tracepoint" -%}
 use aya::programs::RawTracePoint;
 {%- endcase %}
-use aya::{include_bytes_aligned, Bpf};
-use aya_log::BpfLogger;
+use aya::{include_bytes_aligned, Ebpf};
+use aya_log::EbpfLogger;
 {% if program_types_with_opts contains program_type -%}
 use clap::Parser;
 {% endif -%}
@@ -86,14 +86,14 @@ async fn main() -> Result<(), anyhow::Error> {
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
     #[cfg(debug_assertions)]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
+    let mut bpf = Ebpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/debug/{{project-name}}"
     ))?;
     #[cfg(not(debug_assertions))]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
+    let mut bpf = Ebpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/{{project-name}}"
     ))?;
-    if let Err(e) = BpfLogger::init(&mut bpf) {
+    if let Err(e) = EbpfLogger::init(&mut bpf) {
         // This can happen if you remove all log statements from your eBPF program.
         warn!("failed to initialize eBPF logger: {}", e);
     }

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -122,11 +122,11 @@ async fn main() -> Result<(), anyhow::Error> {
     program.load()?;
     program.attach(cgroup)?;
     {%- when "sk_msg" -%}
-    let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
-    prog.load()?;
-
     let sock_map: SockHash::<_, SockKey> = bpf.map("{{sock_map}}").unwrap().try_into()?;
     let map_fd = sock_map.fd();
+
+    let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
+    prog.load()?;
     prog.attach(map_fd)?;
     // insert sockets to the map using sock_map.insert here, or from a sock_ops program
     {%- when "xdp" -%}

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -123,11 +123,11 @@ async fn main() -> Result<(), anyhow::Error> {
     program.attach(cgroup)?;
     {%- when "sk_msg" -%}
     let sock_map: SockHash::<_, SockKey> = bpf.map("{{sock_map}}").unwrap().try_into()?;
-    let map_fd = sock_map.fd();
+    let map_fd = sock_map.fd().try_clone()?;
 
     let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     prog.load()?;
-    prog.attach(map_fd)?;
+    prog.attach(&map_fd)?;
     // insert sockets to the map using sock_map.insert here, or from a sock_ops program
     {%- when "xdp" -%}
     let program: &mut Xdp = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -123,11 +123,11 @@ async fn main() -> Result<(), anyhow::Error> {
     program.attach(cgroup)?;
     {%- when "sk_msg" -%}
     let sock_map: SockHash::<_, SockKey> = bpf.map("{{sock_map}}").unwrap().try_into()?;
-    let map_fd = sock_map.fd()?;
+    let map_fd = sock_map.fd();
 
     let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     prog.load()?;
-    prog.attach(map_fd.into())?;
+    prog.attach(map_fd)?;
     // insert sockets to the map using sock_map.insert here, or from a sock_ops program
     {%- when "xdp" -%}
     let program: &mut Xdp = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -122,11 +122,11 @@ async fn main() -> Result<(), anyhow::Error> {
     program.load()?;
     program.attach(cgroup)?;
     {%- when "sk_msg" -%}
-    let sock_map: SockHash::<_, SockKey> = bpf.map("{{sock_map}}").unwrap().try_into()?;
-    let map_fd = sock_map.fd();
-
     let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     prog.load()?;
+
+    let sock_map: SockHash::<_, SockKey> = bpf.map("{{sock_map}}").unwrap().try_into()?;
+    let map_fd = sock_map.fd();
     prog.attach(map_fd)?;
     // insert sockets to the map using sock_map.insert here, or from a sock_ops program
     {%- when "xdp" -%}

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let prog: &mut SkMsg = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
     prog.load()?;
-    prog.attach(map_fd)?;
+    prog.attach(map_fd.into())?;
     // insert sockets to the map using sock_map.insert here, or from a sock_ops program
     {%- when "xdp" -%}
     let program: &mut Xdp = bpf.program_mut("{{crate_name}}").unwrap().try_into()?;
@@ -186,6 +186,7 @@ async fn main() -> Result<(), anyhow::Error> {
             perf_event::perf_sw_ids::PERF_COUNT_SW_CPU_CLOCK as u64,
             perf_event::PerfEventScope::AllProcessesOneCpu { cpu },
             perf_event::SamplePolicy::Frequency(1),
+            true,
         )?;
     }
     {%- when "raw_tracepoint" -%}


### PR DESCRIPTION
Based on https://github.com/aya-rs/aya/commit/41c61560eae01a30c703ea22c5bfeeff0ecf6b1b, it's necessary to use aya-ebpf instead of aya-bpf.