### PR TITLE
feat: add emacs directory locals to configure rust-analyzer

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((lsp-mode . ((lsp-rust-analyzer-linked-projects . ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]))))


### PR DESCRIPTION
.dir-locals.el is the emacs equivalent of .vim directory in the project here. 

This PR adds a simple configuration to map the same rust-analyzer configuration variable as the vim version to make use of new aya projects seamless with emacs projects that use emacs-lsp + rust analyzer.