### PR TITLE
feat: custom target directory support

### DIFF
--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -32,8 +32,8 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let target_dir = std::env!("CARGO_TARGET_DIR");
-    let bin_path = format!("{target_dir}/{profile}/{{project-name}}");
+    let target_path = std::env::var("CARGO_TARGET_DIR").unwrap_or("target".into());
+    let bin_path = format!("{target_path}/{profile}/{{project-name}}");
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -32,7 +32,8 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{profile}/{{project-name}}");
+    let target_dir = std::env!("CARGO_TARGET_DIR");
+    let bin_path = format!("{target_dir}/{profile}/{{project-name}}");
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -86,13 +86,15 @@ async fn main() -> Result<(), anyhow::Error> {
     // like to specify the eBPF program at runtime rather than at compile-time, you can
     // reach for `Bpf::load_file` instead.
     #[cfg(debug_assertions)]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/{{project-name}}"
-    ))?;
+    let mut bpf = Bpf::load(include_bytes_aligned!(concat!(
+        std::env!("CARGO_TARGET_DIR"),
+        "/bpfel-unknown-none/debug/{{project-name}}"
+    )))?;
     #[cfg(not(debug_assertions))]
-    let mut bpf = Bpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/{{project-name}}"
-    ))?;
+    let mut bpf = Bpf::load(include_bytes_aligned!(concat!(
+        std::env!("CARGO_TARGET_DIR"),
+        "/bpfel-unknown-none/release/{{project-name}}"
+    )))?;
     if let Err(e) = BpfLogger::init(&mut bpf) {
         // This can happen if you remove all log statements from your eBPF program.
         warn!("failed to initialize eBPF logger: {}", e);


### PR DESCRIPTION
If you have CARGO_TARGET_DIR in your config, a new aya project would not compile/execute out of the box. This PR attempts to fix that by reading the CARGO_TARGET_DIR path from the environment and using that to locate the compiled ebpf bundle.
