### PR TITLE
fix: emacs directory locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,1 @@
-((lsp-mode . ((lsp-rust-analyzer-linked-projects . ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]))))
+((prog-mode . ((lsp-rust-analyzer-linked-projects . ["Cargo.toml" "{{project-name}}-ebpf/Cargo.toml"]))))


### PR DESCRIPTION
- Emacs vectors do not have "," separator.
- The .dir-locals.el list is checked against major mode names, but lsp-mode could be a minor mode. Use the generic prog-mode instead.