### PR TITLE
docs: update LSM hook prompt to reference lsm_hook_defs.h

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -71,7 +71,7 @@ regex = "^[a-z_]+$"
 
 [conditional.'program_type == "lsm"'.placeholders.lsm_hook]
 type = "string"
-prompt = "Which lsm hook? (e.g file_open, task_alloc) You can find a list of hooks in include/linux/lsm_hooks.h in the kernel source tree."
+prompt = "Which lsm hook? (e.g file_open, task_alloc) You can find a list of hooks in include/linux/lsm_hook_defs.h in the kernel source tree."
 regex = "^[a-z_]+$"
 
 [hooks]


### PR DESCRIPTION
In newer kernel versions the hooks have been moved to `lsm_hook_defs.h`:

```
$ grep file_open /usr/src/kernels/6.10.9-200.fc40.x86_64/include/linux/lsm_hooks.h
$ grep file_open /usr/src/kernels/6.10.9-200.fc40.x86_64/include/linux/lsm_hook_defs.h
LSM_HOOK(int, 0, file_open, struct file *file)
```

So I think this info could be added to the prompt.