### PR TITLE
ebpf: consolidate rust-analyzer settings

### DIFF
--- a/.cargo/rust-analyzer.toml
+++ b/.cargo/rust-analyzer.toml
@@ -1,0 +1,2 @@
+[rust-analyzer]
+linkedProjects = ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((prog-mode . ((lsp-rust-analyzer-linked-projects . ["Cargo.toml" "{{project-name}}-ebpf/Cargo.toml"]))))

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,3 +1,0 @@
-{
-  "rust-analyzer.linkedProjects": ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "rust-analyzer.linkedProjects": ["Cargo.toml", "{{project-name}}-ebpf/Cargo.toml"]
-}


### PR DESCRIPTION
Add rust-analyzer.toml configuration file for all IDEs that use rust-analyzer.