### PR TITLE
Build on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,15 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: 00 4 * * *
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This matches the version used in the bpf-linker binstall job. Otherwise
we fail with:
```
  = note: bpf-linker: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by bpf-linker)
          bpf-linker: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by bpf-linker)
          bpf-linker: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by bpf-linker)
```

Add a nightly build so we catch these earlier.
