### PR TITLE
ebpf: merge rust-analyzer settings

### DIFF
--- a/{{project-name}}-ebpf/.cargo/rust-analyzer.toml
+++ b/{{project-name}}-ebpf/.cargo/rust-analyzer.toml
@@ -1,0 +1,5 @@
+[target]
+cargo.target = "bpfel-unknown-none"
+
+[checkOnSave]
+allTargets = false

--- a/{{project-name}}-ebpf/.vim/coc-settings.json
+++ b/{{project-name}}-ebpf/.vim/coc-settings.json
@@ -1,4 +1,0 @@
-{
-    "rust-analyzer.cargo.target": "bpfel-unknown-none",
-    "rust-analyzer.checkOnSave.allTargets": false
-}

--- a/{{project-name}}-ebpf/.vscode/settings.json
+++ b/{{project-name}}-ebpf/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "rust-analyzer.cargo.target": "bpfel-unknown-none",
-    "rust-analyzer.checkOnSave.allTargets": false
-}


### PR DESCRIPTION
The `{{project-name}}-ebpf/.vim/coc-settings.json` and `{{project-name}}-ebpf/.vsocde/settings.json` is same config. can be merge to `{{project-name}}-ebpf/.cargo/rust-analyzer.toml`.