### PR TITLE
fix: Prerequisites order in README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Prerequisites
 
 1. stable rust toolchains: `rustup toolchain install stable`
-1. nightly rust toolchains: `rustup toolchain install nightly --component rust-src`
-1. (if cross-compiling) rustup target: `rustup target add ${ARCH}-unknown-linux-musl`
-1. (if cross-compiling) LLVM: (e.g.) `brew install llvm` (on macOS)
-1. (if cross-compiling) C toolchain: (e.g.) [`brew install filosottile/musl-cross/musl-cross`](https://github.com/FiloSottile/homebrew-musl-cross) (on macOS)
-1. bpf-linker: `cargo install bpf-linker` (`--no-default-features` on macOS)
+2. nightly rust toolchains: `rustup toolchain install nightly --component rust-src`
+3. (if cross-compiling) rustup target: `rustup target add ${ARCH}-unknown-linux-musl`
+4. (if cross-compiling) LLVM: (e.g.) `brew install llvm` (on macOS)
+5. (if cross-compiling) C toolchain: (e.g.) [`brew install filosottile/musl-cross/musl-cross`](https://github.com/FiloSottile/homebrew-musl-cross) (on macOS)
+6. bpf-linker: `cargo install bpf-linker` (`--no-default-features` on macOS)
 
 ## Build & Run
 


### PR DESCRIPTION
despite the output of 
```md
1. first
1. second
1. third
```
and
```md
1. first
2. second
3. third
```
are the same, it's better to specify the ordered list with distinct numbers IMO 