### PR TITLE
refactor: use `target_arch = "bpf"` for `panic_handler`

### DIFF
--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -319,7 +319,7 @@ fn try_{{crate_name}}(ctx: PerfEventContext) -> Result<u32, u32> {
 }
 {%- endcase %}
 
-#[cfg(not(test))]
+#[cfg(target_arch = "bpf")]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
Related: https://github.com/aya-rs/book/issues/214