### PR TITLE
Rename output of -ebpf crate

### DIFF
--- a/{{project-name}}-ebpf/Cargo.toml
+++ b/{{project-name}}-ebpf/Cargo.toml
@@ -13,5 +13,5 @@ aya-log-ebpf = { workspace = true }
 which = { workspace = true }
 
 [[bin]]
-name = "{{ project-name }}"
+name = "{{ project-name }}_ebpf"
 path = "src/main.rs"

--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     // reach for `Bpf::load_file` instead.
     let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
         env!("OUT_DIR"),
-        "/{{project-name}}"
+        "/{{project-name}}_ebpf"
     )))?;
     if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
         // This can happen if you remove all log statements from your eBPF program.


### PR DESCRIPTION
This makes it possible to run `cargo doc --workspace` and get both the eBPF and normal crate and their dependencies in the output docs.

Fixes: https://github.com/aya-rs/aya/issues/1260