### PR TITLE
fix: update tracepoint_name regex to allow colon (:)

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -67,7 +67,7 @@ regex = "^[a-z_]+$"
 [conditional.'program_type == "tracepoint" || program_type == "tp_btf" || program_type == "raw_tracepoint"'.placeholders.tracepoint_name]
 type = "string"
 prompt = "Which tracepoint name? (e.g sched_switch, net_dev_queue)"
-regex = "^[a-z_]+$"
+regex = "^[a-z_:]+$"
 
 [conditional.'program_type == "lsm"'.placeholders.lsm_hook]
 type = "string"


### PR DESCRIPTION
This PR updates the validation logic for tracepoint_name to allow full tracepoint names such as syscalls:sys_enter_execve, which are commonly used with tools like perf or eBPF tracing.

📜 Background
Currently, when generating a project using cargo generate, entering tracepoints like syscalls:sys_enter_execve throws a validation error. However, this is a valid tracepoint format.

This PR fixes that by updating the regular expression used for validation.

✅ Changes
Updates the regex pattern in cargo-generate.toml to accept : in tracepoint names.

🔍 Why this is useful?
It aligns the template with real-world usage where full tracepoint names include colons and helps new users avoid unnecessary confusion during project setup.
as show in image attached
![Screenshot_2025-06-08_11-16-28](https://github.com/user-attachments/assets/5ebb70f2-38ad-44d9-8b56-995070c5c5fe)
