### PR TITLE
do not strip ebpf in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ which = { version = "6.0.0", default-features = false }
 [profile.release.package.{{project-name}}-ebpf]
 debug = 2
 codegen-units = 1
+strip = false


### PR DESCRIPTION
Because `set_global` relies on debug symbols, the eBPF should not be striped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/149)
<!-- Reviewable:end -->
