### PR TITLE
Add .cargo/config.toml for eBPF build configuration

### DIFF
--- a/{{project-name}}-ebpf/.cargo/config.toml
+++ b/{{project-name}}-ebpf/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core", "alloc"]


### PR DESCRIPTION
Should fix https://github.com/aya-rs/book/issues/232

## Problem
The current xdp-hello example fails to build with `cargo build` because the `bpfel-unknown-none` target requires building the standard library from source. Users get this error:

```
error: component 'rust-std' for target 'bpfel-unknown-none' is unavailable for download
```

## Solution
Add `.cargo/config.toml` to the xdp-hello-ebpf example with the required build configuration:

```toml
[build]
target = "bpfel-unknown-none"

[unstable]
build-std = ["core", "alloc"]
```

## Files Changed
- `examples/xdp-hello/xdp-hello-ebpf/.cargo/config.toml` (new file)

## Result
- `cargo build` now works as documented

## Context
The `bpfel-unknown-none` target doesn't have pre-compiled standard library components available through rustup, so `-Zbuild-std=core,alloc` is required to build the standard library from source. Adding this to the config file makes the build "just work" as the documentation suggests.