### PR TITLE
Enable the help and usage features for clap in the bin crate member

### DIFF
--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -22,7 +22,11 @@ tokio = { workspace = true, features = [
     "signal",
 ] }
 {% if program_types_with_opts contains program_type -%}
-clap = { workspace = true, default-features = true, features = ["derive"] }
+clap = { workspace = true, default-features = false, features = [
+    "derive",
+    "help",
+    "usage"
+] }
 {% endif -%}
 
 [build-dependencies]

--- a/{{project-name}}/Cargo.toml
+++ b/{{project-name}}/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = [
     "signal",
 ] }
 {% if program_types_with_opts contains program_type -%}
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, default-features = true, features = ["derive"] }
 {% endif -%}
 
 [build-dependencies]


### PR DESCRIPTION
clap doesn't generate help without the default features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/161)
<!-- Reviewable:end -->
