### PR TITLE
Add ability to have a pin version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,20 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [workspace.dependencies]
+{% if rev_version != "" %}
+aya = { git = "https://github.com/aya-rs/aya", rev = "{{ rev_version }}", default-features = false }
+aya-build = { git = "https://github.com/aya-rs/aya", rev = "{{ rev_version }}", default-features = false }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", rev = "{{ rev_version }}", default-features = false }
+aya-log = { git = "https://github.com/aya-rs/aya", rev = "{{ rev_version }}", default-features = false }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", rev = "{{ rev_version }}", default-features = false }
+{% else %}
 aya = { git = "https://github.com/aya-rs/aya", default-features = false }
 aya-build = { git = "https://github.com/aya-rs/aya", default-features = false }
 aya-ebpf = { git = "https://github.com/aya-rs/aya", default-features = false }
 aya-log = { git = "https://github.com/aya-rs/aya", default-features = false }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya", default-features = false }
+{% endif %}
+
 
 anyhow = { version = "1", default-features = false }
 # `std` feature is currently required to build `clap`.


### PR DESCRIPTION
### What

This PR adds support for an optional pinned version (`rev_version`) for Aya crates
(aya, aya-build, aya-ebpf, aya-log, aya-log-ebpf) in the aya-template.

### Why

Previously, the template always pointed to the `main` branch of the Aya repository.
As a result, cargo-generate could break when new commits in Aya changed the public API
(e.g., removal of `cargo_metadata` from `aya-build`).

With this change, users can optionally provide `rev_version` to pin the template
dependencies to a specific commit, making generated projects more stable and reproducible.

### Example usage

```bash
cargo generate https://github.com/aya-rs/aya-template --name my-project -d rev_version=a18e283e2afd6b85511f6f180069410def79f473

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/162)
<!-- Reviewable:end -->
