### PR TITLE
ci: bump bpf-linker llvm to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,9 @@ jobs:
           brew update && brew install filosottile/musl-cross/musl-cross llvm
           echo $(brew --prefix llvm)/bin >> $GITHUB_PATH
 
-      - run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git --no-default-features --features llvm-21
-        if: runner.os == 'macos'
-
-      - run: cargo install bpf-linker --git https://github.com/aya-rs/bpf-linker.git
-        if: runner.os == 'Linux'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: bpf-linker
 
       - run: sudo apt update && sudo apt install expect
         if: runner.os == 'Linux'


### PR DESCRIPTION
Bring over the LLVM logic from aya-rs/aya since LLVM 22 isn't yet
available from package managers. We could probably extract this into an
action for reuse but this need goes away with binstalls, so let's hope
those arrive sooner rather than later.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/172)
<!-- Reviewable:end -->
