### PR TITLE
fix: specify path and function for u{ret}probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,13 @@ jobs:
       - run: ./test.sh ${{ github.workspace }} ${{ matrix.program }}
         env:
           CRATE_NAME: ${{ matrix.crate_name }}
+
+  check:
+    if: always()
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
             program: kprobe
           - runner: macos-15 # arm64
             program: kprobe
+          # Test that crate_name == program_type doesn't cause duplicate symbol errors.
+          - runner: ubuntu-latest
+            program: uprobe
+            crate_name: uprobe
+          - runner: ubuntu-latest
+            program: uretprobe
+            crate_name: uretprobe
 
     runs-on: ${{ matrix.runner }}
 
@@ -96,3 +103,5 @@ jobs:
         if: runner.os == 'Linux'
 
       - run: ./test.sh ${{ github.workspace }} ${{ matrix.program }}
+        env:
+          CRATE_NAME: ${{ matrix.crate_name }}

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ if [ -z "${PROG_TYPE}" ]; then
   echo "program type required"
   exit 1
 fi
-CRATE_NAME=aya-test-crate
+CRATE_NAME=${CRATE_NAME:-aya-test-crate}
 
 case ${PROG_TYPE} in
 "cgroup_sockopt")

--- a/{{project-name}}-ebpf/src/main.rs
+++ b/{{project-name}}-ebpf/src/main.rs
@@ -69,7 +69,7 @@ fn try_{{crate_name}}(ctx: FExitContext) -> Result<u32, u32> {
 use aya_ebpf::{macros::uprobe, programs::ProbeContext};
 use aya_log_ebpf::info;
 
-#[uprobe]
+#[uprobe(path = "{{uprobe_target}}", function = "{{uprobe_fn_name}}")]
 pub fn {{crate_name}}(ctx: ProbeContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,
@@ -85,7 +85,7 @@ fn try_{{crate_name}}(ctx: ProbeContext) -> Result<u32, u32> {
 use aya_ebpf::{macros::uretprobe, programs::RetProbeContext};
 use aya_log_ebpf::info;
 
-#[uretprobe]
+#[uretprobe(path = "{{uprobe_target}}", function = "{{uprobe_fn_name}}")]
 pub fn {{crate_name}}(ctx: RetProbeContext) -> u32 {
     match try_{{crate_name}}(ctx) {
         Ok(ret) => ret,


### PR DESCRIPTION
## Background

aya-template generated programs could fail with duplicate symbol error if user name the project the same as its program_type(e.g., for `kprobe` program, the project is also named `kprobe`)

See: https://github.com/aya-rs/aya/issues/1027

## Fix

We could warn user and reject the generation, but at least for `uprobe` and `uretprobe`, there exists a simple fix by 
specify `path` and `function` for the generated ebpf code.

Fixes https://github.com/aya-rs/aya/issues/1027.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/173)
<!-- Reviewable:end -->
