### PR TITLE
Change the env_logger level to DEBUG

### DIFF
--- a/{{project-name}}/src/main.rs
+++ b/{{project-name}}/src/main.rs
@@ -75,7 +75,9 @@ async fn main() -> anyhow::Result<()> {
 {%- if program_types_with_opts contains program_type %}
     let opt = Opt::parse();
 {% endif %}
-    env_logger::init();
+    env_logger::Builder::from_default_env()
+        .filter(None, log::LevelFilter::Debug)
+        .init();
 
     // Bump the memlock rlimit. This is needed for older kernels that don't use the
     // new memcg based accounting, see https://lwn.net/Articles/837122/


### PR DESCRIPTION
In the `{{project-name}}-ebpf`, we are using `log::info!()`, but the default `env_logger::init()` only show error level log.

Changed the code to show debug log by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/aya-template/175)
<!-- Reviewable:end -->
